### PR TITLE
NP-1102: Addition of .ci-operator.yaml and some owners

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/OWNERS
+++ b/OWNERS
@@ -4,4 +4,4 @@ approvers:
   - core-approvers
 
 component: Networking
-subcomponent: cluster-network-operator
+subcomponent: ansible-ocp-networking-migration-rollback

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,21 +1,33 @@
 aliases:
   core-approvers:
   - abhat
+  - arghosh93
   - danwinship
   - dougbtv
+  - gsr-shanks
   - JacobTanenbaum
   - jcaamano
   - knobunc
   - kyrtapz
+  - Meina-rh
   - miheer
+  - pliurh
+  - pperiyasamy
   - trozet
+  - zshi-redhat
   core-reviewers:
   - abhat
+  - arghosh93
   - danwinship
   - dougbtv
+  - gsr-shanks
   - JacobTanenbaum
   - jcaamano
   - kyrtapz
+  - Meina-rh
   - miheer
+  - pliurh
+  - pperiyasamy
   - trozet
   - tssurya
+  - zshi-redhat


### PR DESCRIPTION
Add .ci-operator.yaml with the build root image details for the release to process the CI builds.
Also add some more owners.