### PR TITLE
WIP: Change image version from 4.19 to 4.16

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.21-openshift-4.16

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,8 +1,8 @@
 # Stage 1: Builder
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 
 # Stage 2: Final Image
-FROM registry.ci.openshift.org/ocp/4.19:cli
+FROM registry.ci.openshift.org/ocp/4.16:cli
 
 # Set environment variables
 ENV OPERATOR=/usr/local/bin/ansible-operator \


### PR DESCRIPTION
The ipi-sdn workflow can't do installation on 4.19 as OpenShiftSDN CNI has been removed from OCP 4.17 Because of this we can't test migration feature using the CI tests. The release repo https://github.com/openshift/release/pull/61752 has also been updated with this change.